### PR TITLE
Pull in @justin-richling saved files code

### DIFF
--- a/cvdp/cli.py
+++ b/cvdp/cli.py
@@ -57,25 +57,73 @@ def main():
             #Path(save_loc).unlink(missing_ok=True)
             #var_data_array.to_netcdf(save_loc)
             return None"""
-
+    
+    #save_loc.mkdir(parents=True, exist_ok=True)
     #from io import get_input_data
     from file_io import get_input_data
+    #from cvdp.io import get_input_data
     print("PARENT_DIR",PARENT_DIR)
-    ref_datasets, sim_datasets = get_input_data(f"{PARENT_DIR}/example_config.yaml")
 
-    ref_0 = list(ref_datasets.keys())[0]
-    sim_0 = list(sim_datasets.keys())[0]
-
+    # These are dictionaries of datasets
+    ref_datasets, sim_datasets, config_dict = get_input_data(f"{PARENT_DIR}/example_config.yaml")
+    print(list(ref_datasets.keys()))
+    ref_names = list(ref_datasets.keys())
+    sim_names = list(sim_datasets.keys())
+    ref_0_name = ref_names[0]
+    sim_0_name  = sim_names[0]
 
     vns = ["psl"]
     for vn in vns:
-        ref_seas_avgs, sim_seas_avgs, ref_season_anom_avgs, sim_season_anom_avgs, ref_seas_ts, sim_seas_ts = mean_seasonal_calc(ref_datasets[ref_0][vn], sim_datasets[sim_0][vn], vn)
-
+        #print(f"\nProcessing variable: {vn}\n")
+        #ref_seas_avgs, sim_seas_avgs, ref_season_anom_avgs, sim_season_anom_avgs, ref_seas_ts, sim_seas_ts = mean_seasonal_calc(ref_datasets[ref_0][vn], sim_datasets[sim_0][vn], vn)
+        #for ref_0 in ref_names:
+        for ref_0 in [ref_0_name]:
+            print("ref_0",ref_0)
+            print("OH BOY",ref_datasets[ref_0][vn])
+            #for sim_0 in [sim_0_name]:
+            if 1==1:
+                #sim_0_name, sim_datasets[sim_0][vn]
+                data_dict = mean_seasonal_calc(ref_0_name, ref_datasets[ref_0][vn],
+                                               vn, config_dict)
+                ref_seas_avgs = data_dict["seas_avgs"]
+                ref_season_anom_avgs = data_dict["season_anom_avgs"]
+                ref_seas_ts = data_dict["seas_ts"]
+        for sim_0 in [sim_0_name]:
+            print("sim_0",sim_0)
+            print("OH BOY",sim_datasets[sim_0][vn])
+            #for sim_0 in [sim_0_name]:
+            if 1==1:
+                #sim_0_name, sim_datasets[sim_0][vn]
+                data_dict = mean_seasonal_calc(sim_0_name, sim_datasets[sim_0][vn],
+                                               vn, config_dict)
+                sim_seas_avgs = data_dict["seas_avgs"]
+                sim_season_anom_avgs = data_dict["season_anom_avgs"]
+                sim_seas_ts = data_dict["seas_ts"]
         kwargs = {"ref_seas":ref_seas_avgs, "sim_seas":sim_seas_avgs,
-                  "ref_seas_ts":ref_seas_ts, "sim_seas_ts":sim_seas_ts,
-                  "ref_season_anom_avgs":ref_season_anom_avgs, "sim_season_anom_avgs":sim_season_anom_avgs,
-                "vn": vn}
+                        "ref_seas_ts":ref_seas_ts, "sim_seas_ts":sim_seas_ts,
+                        "ref_season_anom_avgs":ref_season_anom_avgs, "sim_season_anom_avgs":sim_season_anom_avgs,
+                        "vn": vn}
         graphics(plot_loc, **kwargs)
+        '''#for ref_0 in ref_names:
+        for ref_0 in [ref_0_name]:
+            print("ref_0",ref_0)
+            print("OH BOY",ref_datasets[ref_0][vn])
+            for sim_0 in [sim_0_name]:
+                data_dict = mean_seasonal_calc(ref_0_name, ref_datasets[ref_0][vn],
+                                               sim_0_name, sim_datasets[sim_0][vn],
+                                               vn, config_dict)
+                ref_seas_avgs = data_dict["ref_seas_avgs"]
+                sim_seas_avgs = data_dict["sim_seas_avgs"]
+                ref_season_anom_avgs = data_dict["ref_season_anom_avgs"]
+                sim_season_anom_avgs = data_dict["sim_season_anom_avgs"]
+                ref_seas_ts = data_dict["ref_seas_ts"]
+                sim_seas_ts = data_dict["sim_seas_ts"]
+
+                kwargs = {"ref_seas":ref_seas_avgs, "sim_seas":sim_seas_avgs,
+                        "ref_seas_ts":ref_seas_ts, "sim_seas_ts":sim_seas_ts,
+                        "ref_season_anom_avgs":ref_season_anom_avgs, "sim_season_anom_avgs":sim_season_anom_avgs,
+                        "vn": vn}
+                graphics(plot_loc, **kwargs)'''
 
 
 if __name__ == '__main__':

--- a/cvdp/cvdp_utils/file_creation.py
+++ b/cvdp/cvdp_utils/file_creation.py
@@ -138,7 +138,7 @@ def data_read_in_3D(fil0,sy,ey,vari, lsmask=None):
     print(f" File Var: {vari}\n")
 
     ds = xr.open_mfdataset(fil0,coords="minimal", compat="override", decode_times=True)
-    print("ds",ds,"\n\n")
+    print("ds raw",ds,"\n\n")
     #print(ds['time'].values,type(ds['time'].values[0]),"\n")
     ds['time'] = convert_to_cftime_no_leap(ds['time'].values,fil0)
     sydata = ds['time'].values[0].year  # start year of data (specified in file name)
@@ -157,7 +157,7 @@ def data_read_in_3D(fil0,sy,ey,vari, lsmask=None):
             ds = xr.decode_cf(ds)
     if vari in ds:
         print(f"    ** The variable {vari} is used for CVDP variable {cvdp_v} **\n")
-    print("ds",ds,"\n\n")
+    print("ds fixed",ds,"\n\n")
     ds = ds.rename({vari : cvdp_v})
     arr = ds.data_vars[cvdp_v]
     ds.close()
@@ -207,7 +207,7 @@ def data_read_in_3D(fil0,sy,ey,vari, lsmask=None):
             print('')
         else:
              arr = arr.sel(time=slice(str(sy).zfill(4)+'-01-01',str(ey).zfill(4)+'-12-31'))
-             print(" arr",arr,"\n\n")
+             print("Time fixed arr",arr,"\n\n")
 
     time_check = arr.time.values
 #    years = time_check.astype('datetime64[Y]').astype(int)+1970

--- a/cvdp/diag/AtmOcnMean.py
+++ b/cvdp/diag/AtmOcnMean.py
@@ -8,9 +8,70 @@ License: MIT
 
 import cvdp_utils.analysis as an
 from diag import compute_seasonal_avgs
+from pathlib import Path
+import xarray as xr
+
+def mean_seasonal_calc(ds_name, dataset, var_name, config_dict):
+    save_loc = config_dict[ds_name]["save_loc"]#.mkdir(parents=True, exist_ok=True)
+    syr = config_dict[ds_name]["syr"]
+    eyr = config_dict[ds_name]["eyr"]
+
+    avgs_filname = f'{ds_name}.cvdp_data.{var_name}.climo.avgs.{syr}-{eyr}.nc'
+    anom_avgs_filename = f'{ds_name}.cvdp_data.{var_name}.climo.anom_avgs.{syr}-{eyr}.nc'
+    ts_filename = f'{ds_name}.cvdp_data.{var_name}.climo.ts.{syr}-{eyr}.nc'
+    avgs_fno = Path(avgs_filname)
+    anom_avgs_fno = Path(anom_avgs_filename)
+    ts_fno = Path(ts_filename)
+    if avgs_fno.is_file() and anom_avgs_fno.is_file() and ts_fno.is_file():
+        print(f"\nFound pre-existing climatology files for {ds_name} {var_name}, loading from disk...\n")
+        seas_avgs = xr.open_dataarray(save_loc / avgs_fno)
+        season_anom_avgs = xr.open_dataarray(save_loc / anom_avgs_fno)
+        seas_ts = xr.open_dataarray(save_loc / ts_fno)
+        data_dict = {
+            "seas_avgs": seas_avgs,
+            "season_anom_avgs": season_anom_avgs,
+            "seas_ts": seas_ts,
+        }
+        return data_dict
+    print("\nCalculating climatological seasonal means...")
+    seas_avgs, season_anom_avgs, seas_ts = compute_seasonal_avgs(dataset, var_name)
+    if "member" in seas_avgs.coords:
+        attrs = seas_avgs.attrs  # save before doing groupby/mean
+        members = seas_avgs.member
+        seas_avgs = seas_avgs.mean(dim="member")
+        seas_avgs.attrs = attrs
+        seas_avgs.attrs["members"] = members
+    
+    #ds = xr.Dataset(trnd_dict)
+    #ds = ds.assign_coords(run=run_name, units=units, syr=syr, eyr=eyr)
+    #for ds_name in config["Data"]:
+        #syr, eyr = config["Data"][ds_name]["start_yr"], config["Data"][ds_name]["end_yr"]
+        #save_loc = Path( config["Paths"]["nc_save_loc"] )
+        #save_loc.mkdir(parents=True, exist_ok=True)
+
+    #fno = f'{ds_name}.cvdp_data.{var_name}.climo.avgs.{syr}-{eyr}.nc'
+    file_name = save_loc / avgs_fno
+    seas_avgs.to_netcdf(file_name)
+
+    #fno = f'{ds_name}.cvdp_data.{var_name}.climo.anom_avgs.{syr}-{eyr}.nc'
+    file_name = save_loc / anom_avgs_fno
+    season_anom_avgs.to_netcdf(file_name)
+
+    #fno = f'{ds_name}.cvdp_data.{var_name}.climo.ts.{syr}-{eyr}.nc'
+    file_name = save_loc / ts_fno
+    seas_ts.to_netcdf(file_name)
+
+    #return ref_seas_avgs, sim_seas_avgs, ref_season_anom_avgs, sim_season_anom_avgs, ref_seas_ts, sim_seas_ts
+    data_dict = {
+        "seas_avgs": seas_avgs,
+        "season_anom_avgs": season_anom_avgs,
+        "seas_ts": seas_ts,
+    }
+    return data_dict
 
 
-def mean_seasonal_calc(ref_dataset, sim_dataset, var_name):
+'''
+def mean_seasonal_calc(ref_name, ref_dataset, sim_name, sim_dataset, var_name, config_dict):
 
     print("\nCalculating climatological seasonal means...")
     ref_seas_avgs, ref_season_anom_avgs, ref_seas_ts = compute_seasonal_avgs(ref_dataset, var_name)
@@ -27,6 +88,45 @@ def mean_seasonal_calc(ref_dataset, sim_dataset, var_name):
         sim_seas_avgs = sim_seas_avgs.mean(dim="member")
         sim_seas_avgs.attrs = attrs
         sim_seas_avgs.attrs["members"] = members
+    #ds = xr.Dataset(trnd_dict)
+    #ds = ds.assign_coords(run=run_name, units=units, syr=syr, eyr=eyr)
+    #for ds_name in config["Data"]:
+        #syr, eyr = config["Data"][ds_name]["start_yr"], config["Data"][ds_name]["end_yr"]
+        #save_loc = Path( config["Paths"]["nc_save_loc"] )
+        #save_loc.mkdir(parents=True, exist_ok=True)
+
+    # Save climatological seasonal means to netCDF
+    save_loc = config_dict[ref_name]["save_loc"]#.mkdir(parents=True, exist_ok=True)
+    syr = config_dict[ref_name]["syr"]
+    eyr = config_dict[ref_name]["eyr"]
+    fno = f'{ref_name}.cvdp_data.{var_name}.climo.avgs.{syr}-{eyr}.nc'
+    file_name = save_loc / fno
+    ref_seas_avgs.to_netcdf(file_name)
+
+    fno = f'{ref_name}.cvdp_data.{var_name}.climo.anom_avgs.{syr}-{eyr}.nc'
+    file_name = save_loc / fno
+    ref_season_anom_avgs.to_netcdf(file_name)
+
+    fno = f'{ref_name}.cvdp_data.{var_name}.climo.ts.{syr}-{eyr}.nc'
+    file_name = save_loc / fno
+    ref_seas_ts.to_netcdf(file_name)
+
+
+
+    save_loc = config_dict[ref_name]["save_loc"]#.mkdir(parents=True, exist_ok=True)
+    syr = config_dict[ref_name]["syr"]
+    eyr = config_dict[ref_name]["eyr"]
+    fno = f'{ref_name}.cvdp_data.{var_name}.climo.avgs.{syr}-{eyr}.nc'
+    file_name = save_loc / fno
+    ref_seas_avgs.to_netcdf(file_name)
+
+    fno = f'{ref_name}.cvdp_data.{var_name}.climo.anom_avgs.{syr}-{eyr}.nc'
+    file_name = save_loc / fno
+    ref_season_anom_avgs.to_netcdf(file_name)
+
+    fno = f'{ref_name}.cvdp_data.{var_name}.climo.ts.{syr}-{eyr}.nc'
+    file_name = save_loc / fno
+    ref_seas_ts.to_netcdf(file_name)
 
     """# If the cases are different shapes, we need to interpolate one to the other first
     #NOTE: the value that comes out of interp_diff is either None, or interpolated difference array
@@ -70,5 +170,15 @@ def mean_seasonal_calc(ref_dataset, sim_dataset, var_name):
 
     #sim_seas_avg, sim_res, sim_fit = af.lin_regress(sim_seas_avgs[f"{vn}_{type}_{season.lower()}"])
     #ref_seas_avg, ref_res, res_fit = af.lin_regress(ref_seas_avgs[f"{vn}_{type}_{season.lower()}"])
-
-    return ref_seas_avgs, sim_seas_avgs, ref_season_anom_avgs, sim_season_anom_avgs, ref_seas_ts, sim_seas_ts
+    
+    #return ref_seas_avgs, sim_seas_avgs, ref_season_anom_avgs, sim_season_anom_avgs, ref_seas_ts, sim_seas_ts
+    data_dict = {
+        "ref_seas_avgs": ref_seas_avgs,
+        "sim_seas_avgs": sim_seas_avgs,
+        "ref_season_anom_avgs": ref_season_anom_avgs,
+        "sim_season_anom_avgs": sim_season_anom_avgs,
+        "ref_seas_ts": ref_seas_ts,
+        "sim_seas_ts": sim_seas_ts
+    }
+    return data_dict
+'''

--- a/cvdp/diag/climatology.py
+++ b/cvdp/diag/climatology.py
@@ -111,5 +111,9 @@ def compute_seasonal_avgs(arr, var_name) -> tuple[xr.Dataset, xr.DataArray, xr.D
     # --- Combine all outputs into dataset ---
     ds = xr.Dataset(trnd_dict)
     ds = ds.assign_coords(run=run_name, units=units, syr=syr, eyr=eyr)
-
+    print("\n***************************************\n")
+    print("DS:",ds,"\n------------------------------------------\n")
+    print("FARR_ANOM",farr_anom,"\n------------------------------------------\n")
+    print("TS_DS:",ts_ds,"\n------------------------------------------\n")
+    print("\n***************************************\n")
     return ds, farr_anom, ts_ds

--- a/example_config.yaml
+++ b/example_config.yaml
@@ -36,13 +36,15 @@ Data:
     start_yr: 1979
     end_yr: 2013
     paths: "/glade/campaign/cesm/collections/cesmLE/CESM-CAM5-BGC-LE/atm/proc/tseries/monthly/*/b.e11.B*C5CNBDRD.f09_g16.001.cam**.PSL.*.nc"
-  
+    #premade_path: /glade/derecho/scratch/richling/cvdp-output/netcdf/1-CESM1-LENS_1-10.cvdp_data.PSL.climo.1979-2013.nc
+
   ERA5:
     reference: True
     variable: "msl"
     start_yr: 1950
     end_yr: 2023
     paths: "/glade/campaign/cgd/cas/observations/ERA5/mon/msl/era5.msl.194001-202312.nc"
+    #premade_path: /glade/derecho/scratch/richling/cvdp-output/netcdf/ERA5.cvdp_data.msl.climo.1950-2023.nc
 
 Paths:
   nc_save_loc: "/glade/derecho/scratch/richling/cvdp-output/netcdf/"


### PR DESCRIPTION
Just adding some features I've been working on for saving intermediate files.

`AtmOcnMean.py` now checks for existence of netcdf files and opens them if so, otherwise it continues to the climo calculations in `diag.climatology.compute_seasonal_avgs`

This includes some more use of the config yaml file `example.yaml`. 

My features include options for saving the netcdf files:
* Top level, single place for netcdf files:

```yaml
Paths:
  nc_save_loc: <saved nc file path>
```

* Case-based file save location:

```yaml
ERA5:
    reference: True
    variable: "msl"
    start_yr: 1950
    end_yr: 2023
    paths: "/glade/campaign/cgd/cas/observations/ERA5/mon/msl/era5.msl.194001-202312.nc"
    nc_save_loc: <saved nc file path>
```

* Already made climo/ts file path `premade_path` for each case:

```yaml
ERA5:
    reference: True
    variable: "msl"
    start_yr: 1950
    end_yr: 2023
    paths: "/glade/campaign/cgd/cas/observations/ERA5/mon/msl/era5.msl.194001-202312.nc"
    premade_path: /glade/derecho/scratch/richling/cvdp-output/netcdf/ERA5.cvdp_data.msl.climo.1950-2023.nc
```

This also tries to setup infrastructure to save all data arrays/sets for ensemble means.